### PR TITLE
fix infinite recursion at propagateEvent function

### DIFF
--- a/jquery.multilevelpushmenu.js
+++ b/jquery.multilevelpushmenu.js
@@ -151,6 +151,7 @@
 				$element.on( event , function ( e , ee ) {
 					$element.hide();
 					try {
+						if(!e.pageX || !e.pageY) return false;
 						ee = ee || {
 							pageX: e.pageX,
 							pageY: e.pageY


### PR DESCRIPTION
Fixed an issue where if you clicked on the border between two menu items (at least in Chrome) it results in an infinite recursion, sometimes even crashing the browser.